### PR TITLE
[Fix] 헤더에 잘못된 userId가 들어왔을 경우

### DIFF
--- a/src/modules/responseMessage.ts
+++ b/src/modules/responseMessage.ts
@@ -9,15 +9,16 @@ const message = {
   UPDATE_NICKNAME_SUCCESS: "닉네임 수정 성공",
   READ_USER_SUCCESS: "회원 정보 조회 성공",
   CHANGE_TOGGLE_SUCCESS: "푸시알림 여부 변경 성공",
+  USER_NOT_FOUND: "존재하지 않는 유저입니다.",
 
   // 레코드
   CREATE_RECORD_SUCCESS: "꿈 기록 작성 성공",
   CREATE_RECORD_FAIL: "제목이 필요합니다.",
 
   //voice
-  VOICE_UPLOAD_SUCCESS: '음성 녹음 업로드 성공',
-  WRONG_VOICE_FORM: '음성 녹음 실패 (잘못된 폼 데이터입니다.)',
-  VOICE_PLAY_SUCCESS: '음성 녹음 재생 성공',
+  VOICE_UPLOAD_SUCCESS: "음성 녹음 업로드 성공",
+  WRONG_VOICE_FORM: "음성 녹음 실패 (잘못된 폼 데이터입니다.)",
+  VOICE_PLAY_SUCCESS: "음성 녹음 재생 성공",
 };
 
 export default message;

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -46,16 +46,8 @@ const getUser = async (userId: string) => {
   }
 };
 
-const changeToggle = async (userId: string, toggle: string) => {
+const changeToggle = async (userId: mongoose.Types.ObjectId, toggle: string, user: UserResponseDto) => {
   try {
-    const userObjectId: mongoose.Types.ObjectId = userMocking[parseInt(userId) - 1];
-    // 우린 앱잼단에서 임의의 유저를 사용하기 때문에 여기서 null이 될 수 없음
-    const user: UserResponseDto | null = await User.findById(userObjectId);
-
-    if (!user) {
-      return null;
-    }
-
     // toggle parameter 값이 1이면 푸시알림 설정 O
     if (toggle == "1") {
       user.is_notified = true;
@@ -64,7 +56,7 @@ const changeToggle = async (userId: string, toggle: string) => {
       user.is_notified = false;
     }
 
-    await User.findByIdAndUpdate(userObjectId, user).exec();
+    await User.findByIdAndUpdate(userId, user).exec();
   } catch (err) {
     console.log(err);
     throw err;


### PR DESCRIPTION
## 📌 관련 이슈
Closed #40 

## ✨ 작업 내용
기존: 헤더에 잘못된 userId가 들어와도 200 OK가 뜸 (푸시 알림 토글 변경은 안 됨)
변경: 헤더에 잘못된 userId가 들어오면 404 Not Found가 뜸  (푸시 알림 토글 변경 안 됨)

## 📚 기타
