### PR TITLE
[Fix] logout&lockedAt

### DIFF
--- a/src/loaders/db.ts
+++ b/src/loaders/db.ts
@@ -7,14 +7,13 @@ import agenda from "./agenda";
 import pushMessage from "../modules/pushMessage";
 
 const connectDB = async () => {
-  let firebase;
   try {
     if (admin.apps.length === 0) {
-      firebase = admin.initializeApp({
+      admin.initializeApp({
         credential: admin.credential.cert(serviceAccount as admin.ServiceAccount),
       });
     } else {
-      firebase = admin.app();
+      admin.app();
       console.log("FCM 준비 완료!");
     }
 
@@ -58,6 +57,15 @@ const connectDB = async () => {
         done();
       });
       agenda.start();
+    }
+
+    const jobs = await agenda.jobs({ lockedAt: { $exists: true, $ne: null } });
+
+    if (jobs.length > 0) {
+      for (let i = 0; i < jobs.length; i++) {
+        const job = jobs[i];
+        (job.attrs.lockedAt = null), await job.save();
+      }
     }
 
     const graceful = () => {

--- a/src/services/AuthService.ts
+++ b/src/services/AuthService.ts
@@ -5,6 +5,7 @@ import jwtHandler from "../modules/jwtHandler";
 import { AuthResponseDto } from "../interfaces/auth/AuthResponseDto";
 import { AuthLogoutDto } from "../interfaces/auth/AuthLogoutDto";
 import exceptionMessage from "../modules/exceptionMessage";
+import agenda from "../loaders/agenda";
 
 const kakaoLogin = async (kakaoToken: string, fcmToken: string): Promise<AuthResponseDto | null | undefined> => {
   try {
@@ -219,7 +220,8 @@ const socialLogout = async (authLogoutDto: AuthLogoutDto) => {
 
     const remainedfcmToken = user.fcmTokens.filter((element) => element !== fcmToken);
 
-    await user.updateOne({ fcmTokens: remainedfcmToken });
+    await User.updateOne({ _id: user._id }, { $set: { time: null, isActive: false, fcmTokens: remainedfcmToken } }).exec();
+    await agenda.cancel({ "data.userId": user._id });
 
     return remainedfcmToken;
   } catch (err) {


### PR DESCRIPTION
## 📌 관련 이슈
closed #229 

## ✨ 작업 내용
로그아웃 시, 예약 취소뿐 아니라 time=null, isActive=false로 변경했습니다.
서버 재시작 시, agendaJobs DB를 찾아 lockedAt을 null로 바꾸어 모든 기기에 정상적으로 알림이 가도록 했습니다. lockedAt 필드는 해당 시점에는 내 작업만 처리하겠다는 명시를 통해 다른 작업이 진행되는 것을 막습니다. 따라서 lockedAt을 null로 바꾸어 모든 작업이 정상적으로 처리되도록 합니다.

## 📚 기타
