### PR TITLE
[Fix] 로그아웃 시 해당 유저가 가진 모든 fcm Token 제거

### DIFF
--- a/src/controllers/AuthController.ts
+++ b/src/controllers/AuthController.ts
@@ -6,7 +6,6 @@ import { sendMessageToSlack } from "../modules/slackAPI";
 import { slackMessage } from "../modules/returnToSlackMessage";
 import AuthService from "../services/AuthService";
 import { AuthLogoutDto } from "../interfaces/auth/AuthLogoutDto";
-import exceptionMessage from "../modules/exceptionMessage";
 
 /**
  * @route POST /auth/login
@@ -95,28 +94,18 @@ const reissueToken = async (req: Request, res: Response) => {
 };
 
 /**
- * @Route PATCH /auth/logout
+ * @Route POST /auth/logout
  * @desc social logout
  * @access Private
  */
 const socialLogout = async (req: Request, res: Response) => {
   const userId = req.body.user.id;
-  const fcmToken = req.body.fcmToken;
   const authLogoutDto: AuthLogoutDto = {
     userId,
-    fcmToken,
   };
 
   try {
-    const data = await AuthService.socialLogout(authLogoutDto);
-
-    if (data === null) {
-      return res.status(statusCode.NOT_FOUND).send(util.fail(statusCode.NOT_FOUND, message.NOT_FOUND));
-    }
-
-    if (data === exceptionMessage.NOT_FOUND_FCM) {
-      return res.status(statusCode.NOT_FOUND).send(util.fail(statusCode.NOT_FOUND, message.NOT_FOUND_FCM));
-    }
+    await AuthService.socialLogout(authLogoutDto);
 
     res.status(statusCode.OK).send(util.success(statusCode.OK, message.LOGOUT_SUCCESS));
   } catch (err) {

--- a/src/interfaces/auth/AuthLogoutDto.ts
+++ b/src/interfaces/auth/AuthLogoutDto.ts
@@ -2,5 +2,4 @@ import mongoose from "mongoose";
 
 export interface AuthLogoutDto {
   userId: mongoose.Types.ObjectId;
-  fcmToken: string;
 }

--- a/src/routes/AuthRouter.ts
+++ b/src/routes/AuthRouter.ts
@@ -6,6 +6,6 @@ const router: Router = Router();
 
 router.post("/login", AuthController.socailLogin);
 router.post("/token", AuthController.reissueToken);
-router.patch("/logout", auth, AuthController.socialLogout);
+router.post("/logout", auth, AuthController.socialLogout);
 
 export default router;

--- a/src/services/AuthService.ts
+++ b/src/services/AuthService.ts
@@ -210,24 +210,13 @@ const reissueToken = async (accessToken: string, refreshToken: string) => {
 const socialLogout = async (authLogoutDto: AuthLogoutDto) => {
   try {
     const user = await User.findById(authLogoutDto.userId);
-    const fcmToken = authLogoutDto.fcmToken;
 
-    // 존재하지 않는 유저이거나 fcmToken 안 넣었을 경우
-    if (!user || !fcmToken) {
+    if (!user) {
       return null;
     }
 
-    // 존재하지 않는 fcmToken일 경우
-    if (!user.fcmTokens.includes(fcmToken)) {
-      return exceptionMessage.NOT_FOUND_FCM;
-    }
-
-    const remainedfcmToken = user.fcmTokens.filter((element) => element !== fcmToken);
-
-    await User.updateOne({ _id: user._id }, { $set: { time: null, isActive: false, fcmTokens: remainedfcmToken } }).exec();
+    await User.updateOne({ _id: user._id }, { $set: { time: null, isActive: false, fcmTokens: [] } }).exec();
     await agenda.cancel({ "data.userId": user._id });
-
-    return remainedfcmToken;
   } catch (err) {
     console.log(err);
     throw err;


### PR DESCRIPTION
## 📌 관련 이슈

- Closed #251 

## ✨ 작업 내용
로그아웃 시 해당 유저가 가진 모든 fcm Token을 제거합니다.

## 📚 기타
하나의 계정으로 두 개의 기기를 사용할 경우, 기기 하나에서 로그아웃을 하면 다른 기기 또한 자동 로그아웃이 됩니다. 이 때, 쓸모없는 fcmToken이 DB에 남아있게 되므로 이를 수정하였습니다.
