### PR TITLE
[Fix] 같은 소셜로그인했을 때, 자동로그아웃 된 기기에 알림가는 이슈 해결

### DIFF
--- a/src/services/AuthService.ts
+++ b/src/services/AuthService.ts
@@ -66,11 +66,6 @@ const kakaoLogin = async (kakaoToken: string, fcmToken: string): Promise<AuthRes
     existUser.refreshToken = jwtHandler.getRefreshToken();
     existUser.isAlreadyUser = true;
 
-    // 한 유저가 여러 기기로 로그한 경우
-    if (!existUser.fcmTokens.includes(fcmToken)) {
-      existUser.fcmTokens.push(fcmToken);
-    }
-
     const data: AuthResponseDto = {
       userId: existUser._id,
       isAlreadyUser: existUser.isAlreadyUser,
@@ -146,11 +141,6 @@ const appleLogin = async (appleToken: string, fcmToken: string): Promise<AuthRes
     existUser.accessToken = jwtHandler.getAccessToken(existUser._id);
     existUser.refreshToken = jwtHandler.getRefreshToken();
     existUser.isAlreadyUser = true;
-
-    // 한 유저가 여러 기기로 로그한 경우
-    if (!existUser.fcmTokens.includes(fcmToken)) {
-      existUser.fcmTokens.push(fcmToken);
-    }
 
     const data: AuthResponseDto = {
       userId: existUser._id,

--- a/src/services/AuthService.ts
+++ b/src/services/AuthService.ts
@@ -65,6 +65,7 @@ const kakaoLogin = async (kakaoToken: string, fcmToken: string): Promise<AuthRes
     existUser.accessToken = jwtHandler.getAccessToken(existUser._id);
     existUser.refreshToken = jwtHandler.getRefreshToken();
     existUser.isAlreadyUser = true;
+    existUser.fcmTokens[0] = fcmToken;
 
     const data: AuthResponseDto = {
       userId: existUser._id,
@@ -141,6 +142,7 @@ const appleLogin = async (appleToken: string, fcmToken: string): Promise<AuthRes
     existUser.accessToken = jwtHandler.getAccessToken(existUser._id);
     existUser.refreshToken = jwtHandler.getRefreshToken();
     existUser.isAlreadyUser = true;
+    existUser.fcmTokens[0] = fcmToken;
 
     const data: AuthResponseDto = {
       userId: existUser._id,


### PR DESCRIPTION
## 📌 관련 이슈

- Closed #266 

## ✨ 작업 내용
현재 같은 소셜계정으로 두 기기에서 로그인하면 하나의 기기가 자동로그아웃됩니다. (카카오, 애플 측에서 처리)
따라서 자동로그아웃된 기기에서도 계속해서 푸시알림이 오는 이슈가 있었습니다.
같은 소셜 로그인으로 로그인했을 경우에는 가장 마지막의 토큰만 저장하도록 하여 자동로그아웃 된 기기에서의 푸시알림을 방지합니다.


## 📚 기타
